### PR TITLE
ci: Publish release packages to PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,3 +33,9 @@ jobs:
       with:
         files: |
           assets/*.whl
+
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}
+        packages_dir: assets/


### PR DESCRIPTION
This commti updates the CI workflow to publish the wheel packages to the PyPI when a new release is created.

Signed-off-by: Stephanos Ioannidis <stephanos.ioannidis@nordicsemi.no>