### PR TITLE
ci: Update VS 2022 toolset to 14.39

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,17 +51,17 @@ jobs:
         # Python 3.10
         - python: '3.10'
           builder: windows-2022
-          toolset: '14.37' # Visual Studio 2022
+          toolset: '14.39' # Visual Studio 2022
           winsdk: '10.0.17763.0' # Windows 10 1809
         # Python 3.11
         - python: '3.11'
           builder: windows-2022
-          toolset: '14.37' # Visual Studio 2022
+          toolset: '14.39' # Visual Studio 2022
           winsdk: '10.0.17763.0' # Windows 10 1809
         # Python 3.12
         - python: '3.12'
           builder: windows-2022
-          toolset: '14.37' # Visual Studio 2022
+          toolset: '14.39' # Visual Studio 2022
           winsdk: '10.0.17763.0' # Windows 10 1809
         arch:
         - x86


### PR DESCRIPTION
Visual Studio 2022 14.37 is out of support and no loger included in the GitHub Actions runner images.