### PR TITLE
ci: Use VC toolset 14.40 for windows-2022 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,17 +51,17 @@ jobs:
         # Python 3.10
         - python: '3.10'
           builder: windows-2022
-          toolset: '14.39' # Visual Studio 2022
+          toolset: '14.41' # Visual Studio 2022
           winsdk: '10.0.17763.0' # Windows 10 1809
         # Python 3.11
         - python: '3.11'
           builder: windows-2022
-          toolset: '14.39' # Visual Studio 2022
+          toolset: '14.41' # Visual Studio 2022
           winsdk: '10.0.17763.0' # Windows 10 1809
         # Python 3.12
         - python: '3.12'
           builder: windows-2022
-          toolset: '14.39' # Visual Studio 2022
+          toolset: '14.41' # Visual Studio 2022
           winsdk: '10.0.17763.0' # Windows 10 1809
         arch:
         - x86

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ define_macros = [
     ('WINDOW_HAS_FLAGS', None),
     ('NCURSES_MOUSE_VERSION', 2),
     ('_ISPAD', 0x10),
-    ('is_term_resized', 'is_termresized'),
+    ('\'is_term_resized(nlines, ncols)=is_termresized()\'', None),
 ]
 
 srcdir = 'py%i%i//' % sys.version_info[:2]


### PR DESCRIPTION
This commit updates the CI workflow to use Visual C++ toolset version 14.40 on the Windows Server 2022 runners because 14.39 is no longer available in them.