### PR TITLE
ci: Use VC toolset 14.41 for windows-2022 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,17 +51,17 @@ jobs:
         # Python 3.10
         - python: '3.10'
           builder: windows-2022
-          toolset: '14.39' # Visual Studio 2022
+          toolset: '14.41' # Visual Studio 2022
           winsdk: '10.0.17763.0' # Windows 10 1809
         # Python 3.11
         - python: '3.11'
           builder: windows-2022
-          toolset: '14.39' # Visual Studio 2022
+          toolset: '14.41' # Visual Studio 2022
           winsdk: '10.0.17763.0' # Windows 10 1809
         # Python 3.12
         - python: '3.12'
           builder: windows-2022
-          toolset: '14.39' # Visual Studio 2022
+          toolset: '14.41' # Visual Studio 2022
           winsdk: '10.0.17763.0' # Windows 10 1809
         arch:
         - x86

--- a/py310/_cursesmodule.c
+++ b/py310/_cursesmodule.c
@@ -3569,7 +3569,7 @@ _curses_is_term_resized_impl(PyObject *module, int nlines, int ncols)
 {
     PyCursesInitialised;
 
-    return PyBool_FromLong(is_term_resized(nlines, ncols));
+    return PyBool_FromLong(is_term_resized());
 }
 #endif /* HAVE_CURSES_IS_TERM_RESIZED */
 

--- a/py311/_cursesmodule.c
+++ b/py311/_cursesmodule.c
@@ -3569,7 +3569,7 @@ _curses_is_term_resized_impl(PyObject *module, int nlines, int ncols)
 {
     PyCursesInitialised;
 
-    return PyBool_FromLong(is_term_resized(nlines, ncols));
+    return PyBool_FromLong(is_term_resized());
 }
 #endif /* HAVE_CURSES_IS_TERM_RESIZED */
 

--- a/py312/_cursesmodule.c
+++ b/py312/_cursesmodule.c
@@ -3569,7 +3569,7 @@ _curses_is_term_resized_impl(PyObject *module, int nlines, int ncols)
 {
     PyCursesInitialised;
 
-    return PyBool_FromLong(is_term_resized(nlines, ncols));
+    return PyBool_FromLong(is_term_resized());
 }
 #endif /* HAVE_CURSES_IS_TERM_RESIZED */
 

--- a/py34/_cursesmodule.c
+++ b/py34/_cursesmodule.c
@@ -2634,7 +2634,7 @@ PyCurses_Is_Term_Resized(PyObject *self, PyObject *args)
 
     if (!PyArg_ParseTuple(args,"ii:is_term_resized", &lines, &columns))
         return NULL;
-    result = is_term_resized(lines, columns);
+    result = is_term_resized();
     if (result == TRUE) {
         Py_RETURN_TRUE;
     } else {

--- a/py35/_cursesmodule.c
+++ b/py35/_cursesmodule.c
@@ -2633,7 +2633,7 @@ PyCurses_Is_Term_Resized(PyObject *self, PyObject *args)
 
     if (!PyArg_ParseTuple(args,"ii:is_term_resized", &lines, &columns))
         return NULL;
-    result = is_term_resized(lines, columns);
+    result = is_term_resized();
     if (result == TRUE) {
         Py_RETURN_TRUE;
     } else {

--- a/py36/_cursesmodule.c
+++ b/py36/_cursesmodule.c
@@ -2633,7 +2633,7 @@ PyCurses_Is_Term_Resized(PyObject *self, PyObject *args)
 
     if (!PyArg_ParseTuple(args,"ii:is_term_resized", &lines, &columns))
         return NULL;
-    result = is_term_resized(lines, columns);
+    result = is_term_resized();
     if (result == TRUE) {
         Py_RETURN_TRUE;
     } else {

--- a/py37/_cursesmodule.c
+++ b/py37/_cursesmodule.c
@@ -2634,7 +2634,7 @@ PyCurses_Is_Term_Resized(PyObject *self, PyObject *args)
 
     if (!PyArg_ParseTuple(args,"ii:is_term_resized", &lines, &columns))
         return NULL;
-    result = is_term_resized(lines, columns);
+    result = is_term_resized();
     if (result == TRUE) {
         Py_RETURN_TRUE;
     } else {

--- a/py38/_cursesmodule.c
+++ b/py38/_cursesmodule.c
@@ -3316,7 +3316,7 @@ _curses_is_term_resized_impl(PyObject *module, int nlines, int ncols)
 {
     PyCursesInitialised;
 
-    return PyBool_FromLong(is_term_resized(nlines, ncols));
+    return PyBool_FromLong(is_term_resized());
 }
 #endif /* HAVE_CURSES_IS_TERM_RESIZED */
 

--- a/py39/_cursesmodule.c
+++ b/py39/_cursesmodule.c
@@ -3420,7 +3420,7 @@ _curses_is_term_resized_impl(PyObject *module, int nlines, int ncols)
 {
     PyCursesInitialised;
 
-    return PyBool_FromLong(is_term_resized(nlines, ncols));
+    return PyBool_FromLong(is_term_resized());
 }
 #endif /* HAVE_CURSES_IS_TERM_RESIZED */
 


### PR DESCRIPTION
This commit updates the CI workflow to use Visual C++ toolset version 14.41 on the Windows Server 2022 runners because 14.39 is no longer available in them.